### PR TITLE
docs: Friendly dev docs

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -1,29 +1,21 @@
 # Open Service Mesh Development Guide
 
-Welcome to the Open Service Mesh development guide!
+Thank you for joining us on a journey to build an SMI-native lightweight service mesh. The first of our [core principles](https://github.com/openservicemesh/osm#core-principles) is to create a system, which is "simple to understand and contribute to." We hope that you would find the source code easy to understand. If not - we invite you to help us fulfil this principle. There is no PR too small!
 
-This document will help you build and run Open Service Mesh from source.
-More information about running the demo included in this repo is
-in [/demo/README.md](../demo/README.md).
-The OSM software design is discussed
-in detail in [DESIGN.md](/DESIGN.md).
+To understand *what* Open Service Mesh does - take it for a spin and kick the tires. Install it on your Kubernetes cluster by following [this guide](./example/README.md).
 
-## Table of contents
+To get a deeper understanding of how OSM does what it does - take a look at the detailed [software design](../DESIGN.md).
 
-- [Repo Layout](#repo-layout)
-- [Open Service Mesh Components](#openservicemesh-components)
-- [Development Configurations](#development-configurations)
-- [Helm Chart](#helm-chart)
-- [Build Architecture](#build-architecture)
+When you are ready to jump in - [fork the repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) and then [clone it](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) on your workstation.
 
-
-## Repo Layout
-
+The directories in the cloned repo will be structured approximately like this:
+<details>
+  <summary>Click to expand directory structure</summary>
 This in a non-exhaustive list of the directories in this repo. It is provided
 as a birds-eye view of where the different components are located.
 
   - `charts/` - contains OSM Helm chart
-  - `ci/` - tools and scripts for the continuos integration system
+  - `ci/` - tools and scripts for the continuous integration system
   - `cmd/` - OSM command line tools
   - `crd/` - Custom Resource Definitions needed by OSM
   - `demo/` - scripts and Kubernetes resources needed to run the Bookstore demonstration of Open Service Mesh
@@ -61,46 +53,24 @@ as a birds-eye view of where the different components are located.
     - `smi/` - SMI client, informer, caches and tools
     - `tests/` - test fixtures and other functions to make unit testing easier
     - `trafficpolicy/` - SMI related types
+</details>
+
+The Open Service Mesh controller is written in Go.
+It relies on the [SMI Spec](https://github.com/servicemeshinterface/smi-spec/).
+OSM leverages [Envoy proxy](https://github.com/envoyproxy/envoy) as a data plane and Envoy's [XDS v3](https://github.com/envoyproxy/go-control-plane) protocol.
 
 
-Open Service Mesh (OSM) is written in Go. It relies on the [SMI Spec](https://github.com/servicemeshinterface/smi-spec/) standard
-and leverages [Envoy proxy](https://github.com/envoyproxy/envoy) as a data plane.
-OSM uses Envoy's [go-control-plane (XDS)](https://github.com/envoyproxy/go-control-plane) package.
+## Get Go-ing
 
+This repository uses [Go v1.14](https://golang.org/). If you are not familiar with Go, spend some time with the excellent [Tour of Go](https://tour.golang.org/).
 
+## Get the dependencies
 
-## Open Service Mesh components
+The OSM packages rely on many external Go libraries.
 
-- cli Command-line `osm` utility, view and drive the control
-  plane.
-- Helm chart
-- controller
+Take a peek at the [go.mod](../go.mod) file to see all dependencies.
 
-
-## Development Configurations
-
-Depending on use case, there are several configurations with which to develop
-and run Open Service Mesh.
-The root of the repository contains a file named `.env.example`. Copy the contents of this file into `.env`: `cat .env.example > .env` and modify the contents of `.env` to suite your environment.
-
-TODO:
- - Describe all the environment variables.
- - how to enable various levels of debugging - mostly tracing.
- - Describe the format of the debug messages.
- - How to enable the debug server & how it could be useful.
-
-### Go
-
-This repository uses Go v1.14.
-
-#### Go modules and dependencies
-
-This repo supports [Go Modules](https://github.com/golang/go/wiki/Modules).
-The repo can be cloned outside of the `GOPATH`, since Go Modules support is
-enabled by default since Go version 1.11.
-
-If you are using this repo from within the `GOPATH`,
-activate module support with: `export GO111MODULE=on`
+Run `go get -d ./...` to download all required Go packages.
 
 #### Makefile
 
@@ -114,7 +84,16 @@ More notable:
   - `make go-vet` - same as `go vet ./...`
 
 ## Create Environment Variables
-Create some necessary environment variables. This environment variable setup is a temporary step because OSM is currently a private project and there are no public container images available.
+
+The OSM repo relies on environment variables to make it usable on your localhost. The root of the repository contains a file named `.env.example`. Copy the contents of this file into `.env`
+```bash
+cat .env.example > .env
+```
+Tha various envirnoment variables are documented in the `.env` file itself. Modify the variables in `.env` to suite your environment.
+
+Some of the scripts and build targets available expect an accessible container registry where to push the `osm-controller` and `init` docker images once compiled. The location and credential options for the container registry can be specified as environment variables declared in `.env`, as well as the target namespace where `osm-controller` will be installed on.
+
+Additionally, if using `demo/` scripts to deploy OSM's provided demo on your own K8s cluster, the same container registry configured in `.env` will be used to pull OSM images on your K8s cluster.
 ```console
 $ # K8S_NAMESPACE is the Namespace the control plane will be installed into
 $ export K8S_NAMESPACE=osm-system
@@ -131,16 +110,17 @@ $ # Create docker secret in Kubernetes Namespace using following script:
 $ ./scripts/create-container-registry-creds.sh "$K8S_NAMESPACE"
 
 ```
+(NOTE: these requirements are true for automatic demo deployment using the available demo scripts, #1416 tracks an improvement to not strictly require these and use upstream images from official dockerhub registry if a user does not want/need changes on the code)
 
 ## Build and push OSM images
-Build and push images necessary to install OSM. This is also a temporary step because OSM is currently a private project and there are no public container images available.
+For development an/or testing locally compiled builds, pushing the local image to a container registry is still required. The following build targets will do so automatically against the configured container registry.
 
 ```console
-$ make docker-push-osm-controller
-$ make docker-push-init
+make docker-push-osm-controller
+make docker-push-init
 ```
 
-#### Formatting
+## Code Formatting
 
 All Go source code is formatted with `goimports`. The version of `goimports`
 used by this project is specified in `go.mod`. To ensure you have the same
@@ -149,23 +129,7 @@ golang.org/x/tools/cmd/goimports`. It's recommended that you set your IDE or
 other development tools to use `goimports`. Formatting is checked during CI by
 the `bin/fmt` script.
 
-
-TODO
- - what about the golangci-lint ?
- - how to use the OSM cli
- - how do you deploy
- - how do you run CI
- - how do you run the demo
-
-TODO: Explain how the git commit hash is embedded in the binary.
-
-#### Docker
-
-TODO:
-  - what docker images are there - what they are
-  - how we build and push to a public repository
-
-## Helm chart
+## Helm charts
 
 The Open Service Mesh control plane chart is located in the
 [`charts/osm`](/charts/osm) folder.
@@ -182,10 +146,7 @@ The different chart templates are used as follows:
 - `prometheus-*.yaml` chart templates are used to deploy a Prometheus instance when the metrics stack is enabled
 - `zipkin-*.yaml` chart templates are used to deploy a Zipkin instance when Zipkin tracing is enabled
 
+## Custom Resource Definitions
+
 The [`charts/osm/crds/`](/charts/osm/crds/) folder contains the charts corresponding to the SMI CRDs.
 Experimental CRDs can be found under [`charts/osm/crds/experimental/`](/charts/osm/crds/experimental/).
-
-
-## Build & CI Architecture
-
-[TODO]


### PR DESCRIPTION
With influx of new gophers coming to the repo we need to update the dev docs to help onboarding to the repo easier.
This PR removes a few stale TODOs, also makes the list of directories collapsable. Adding our guiding principle on how we think about the code base.